### PR TITLE
feat: Add silent support

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -1,3 +1,5 @@
+//go:build !silent
+
 package corelog
 
 import (

--- a/silent_handler.go
+++ b/silent_handler.go
@@ -11,6 +11,16 @@ import (
 // This dummies out all of the logging functionality, so that code using the
 // logger will be silent, if the build tag silent is used.
 
+const (
+	nameKey   = "$name"
+	stackKey  = "$stack"
+	errorKey  = "$err"
+	msgKey    = "$msg"
+	timeKey   = "$time"
+	levelKey  = "$level"
+	sourceKey = "$source"
+)
+
 type namedHandler struct{}
 
 func (h namedHandler) Enabled(ctx context.Context, level slog.Level) bool {

--- a/silent_handler.go
+++ b/silent_handler.go
@@ -21,7 +21,11 @@ const (
 	sourceKey = "$source"
 )
 
-type namedHandler struct{}
+type namedHandler struct {
+	name  string
+	attrs []slog.Attr
+	group string
+}
 
 func (h namedHandler) Enabled(ctx context.Context, level slog.Level) bool {
 	return false

--- a/silent_handler.go
+++ b/silent_handler.go
@@ -1,0 +1,34 @@
+//go:build silent
+
+package corelog
+
+import (
+	"context"
+	"log/slog"
+	"os"
+)
+
+// This dummies out all of the logging functionality, so that code using the
+// logger will be silent, if the build tag silent is used.
+
+type namedHandler struct{}
+
+func (h namedHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return false
+}
+func (h namedHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return h
+}
+func (h namedHandler) WithGroup(name string) slog.Handler {
+	return h
+}
+func (h namedHandler) Handle(ctx context.Context, record slog.Record) error {
+	return nil
+}
+
+func newTintHandler(_ Config, _ string, _ *os.File) slog.Handler {
+	return namedHandler{}
+}
+func newJSONHandler(_ Config, _ string, _ *os.File) *slog.JSONHandler {
+	return slog.NewJSONHandler(nil, nil)
+}


### PR DESCRIPTION
A new handler has been added, which will be used if the "silent" build tag is present during building. It will cause all logging messages to be quietly discarded. This would allow codebases using this logger, such as Defradb, to continue using the logger exactly as is, but disable the logging at build time.